### PR TITLE
docs: archive Netease Music Tasks image

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -18,7 +18,6 @@ on:
         options:
           - maddy
           - download-bot
-          - netease-cloud-music-tasks
       publish:
         description: Push the multi-architecture image to Docker Hub
         type: boolean
@@ -67,7 +66,7 @@ jobs:
             fi
           done
 
-          for project in maddy download-bot netease-cloud-music-tasks; do
+          for project in maddy download-bot; do
             if [[ "$workflow_changed" == true ]] || printf '%s\n' "${files[@]}" | grep -q "^images/${project}/"; then
               projects+=("$project")
             fi

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           set -euo pipefail
           case "$PROJECT" in
-            maddy|download-bot|netease-cloud-music-tasks) ;;
+            maddy|download-bot) ;;
             *) echo "Unsupported project: $PROJECT" >&2; exit 1 ;;
           esac
           if [[ "$PLATFORMS" != "linux/amd64" && "$PLATFORMS" != "linux/amd64,linux/arm64" ]]; then

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository collects useful open-source projects, packages them for multiple
 | --- | --- | --- | --- |
 | [Maddy](images/maddy/) | All-in-one mail server | AMD64 / ARM64 | Maintained |
 | [Download Bot](images/download-bot/) | Telegram-driven downloads | AMD64 / ARM64 | Community |
-| [Netease Music Tasks](images/netease-cloud-music-tasks/) | Scheduled automation | AMD64 / ARM64 | Community |
+| [Netease Music Tasks](images/netease-cloud-music-tasks/) | Scheduled automation | AMD64 / ARM64 | Archived upstream |
 | [X-UI](images/x-ui/) | Network management panel | Multi-arch | Moved / legacy |
 | [Firefox Send](images/firefox-send/) | Self-hosted file sharing | AMD64 | Archived upstream |
 

--- a/docs/image-publishing.md
+++ b/docs/image-publishing.md
@@ -4,7 +4,7 @@ Docker images are validated on pull requests and published only by an explicit m
 
 ## Pull-request validation
 
-Changes under `images/maddy/`, `images/download-bot/`, or `images/netease-cloud-music-tasks/` trigger an AMD64 Buildx build without registry credentials and without pushing an image. A change to the supply-chain workflow validates all three publishable projects. `x-ui` still receives static Dockerfile and Compose checks, but image builds are intentionally excluded until its source inputs are reproducible.
+Changes under `images/maddy/` or `images/download-bot/` trigger an AMD64 Buildx build without registry credentials and without pushing an image. A change to the supply-chain workflow validates both publishable projects. `netease-cloud-music-tasks` and `x-ui` still receive static Dockerfile, Compose, and historical build checks, but are excluded from publishing because their lifecycle or source inputs are not suitable for a maintained release.
 
 The repository validation workflow also runs Hadolint and parses available Compose files.
 
@@ -20,7 +20,7 @@ The workflow builds AMD64 and ARM64 with QEMU but does not log in or push.
 
 ## Publishing
 
-Publishing requires repository secrets `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`. `x-ui` is intentionally excluded from manual publishing because its current Dockerfile clones a floating upstream revision instead of building the repository-pinned source.
+Publishing requires repository secrets `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`. Archived images are intentionally absent from the manual project selector, and `x-ui` remains excluded because its Dockerfile clones a floating upstream revision instead of building repository-pinned source.
 
 Run the same workflow with `publish: true`. It publishes:
 

--- a/images/netease-cloud-music-tasks/README.md
+++ b/images/netease-cloud-music-tasks/README.md
@@ -1,5 +1,8 @@
 # `netease-cloud-music-tasks`
 
+> [!WARNING]
+> **Archived:** 上游仓库已归档，且本镜像自 2022 年起未再发布。本目录仅保留作历史和迁移参考，不建议用于新的生产部署。
+
 GitHub [enwaiax/awesome-docker](https://github.com/enwaiax/awesome-docker/tree/main/images/netease-cloud-music-tasks)
 Docker [enwaiax/netease-cloud-music-tasks](https://hub.docker.com/r/enwaiax/netease-cloud-music-tasks)
 

--- a/site/src/data/projects.ts
+++ b/site/src/data/projects.ts
@@ -87,11 +87,11 @@ export const projects: Project[] = [
     slug: 'netease-cloud-music-tasks',
     name: 'Netease Music Tasks',
     eyebrow: 'Scheduled jobs',
-    summary: '面向多账号的网易云音乐定时任务容器。',
-    description: '支持签到、云贝任务、定时执行和多种消息推送，并为 AMD64 与 ARM64 环境提供一致的容器运行方式。',
+    summary: '网易云音乐定时任务容器的历史部署方案。',
+    description: '上游仓库已归档，镜像仅保留作历史与迁移参考。现有用户可查阅原部署方式，但不建议在没有安全评估的情况下用于新部署。',
     category: '定时任务',
-    status: 'community',
-    statusLabel: 'Community',
+    status: 'archived',
+    statusLabel: 'Archived',
     accent: '#fb7185',
     glow: 'rgba(251, 113, 133, .22)',
     icon: 'N',
@@ -100,7 +100,7 @@ export const projects: Project[] = [
     sourcePath: 'images/netease-cloud-music-tasks',
     guidePath: 'images/netease-cloud-music-tasks/README.md',
     architectures: ['AMD64', 'ARM64'],
-    tags: ['Scheduler', 'Multi-account', 'Notifications'],
+    tags: ['Scheduler', 'Legacy', 'Archived'],
     ports: [],
     volumes: ['./config.json:/root/config.json'],
     quickStart: `docker run -itd --restart=on-failure \\
@@ -109,7 +109,7 @@ export const projects: Project[] = [
   -e SCHEDULER_MINUTE=30 \\
   --name netease-cloud-music-tasks \\
   enwaiax/netease-cloud-music-tasks:latest`,
-    notes: ['配置文件可能包含账号凭据', '定时参数按容器时区解释', '请遵守上游服务条款'],
+    notes: ['上游仓库已归档，不再建议新部署', '现有镜像最后发布于 2022 年', '配置可能包含账号凭据，迁移或清理时请妥善处理'],
   },
   {
     slug: 'x-ui',


### PR DESCRIPTION
## Summary

Corrects the lifecycle status of Netease Music Tasks after confirming that its upstream repository is archived and its Docker Hub image has not been published since 2022.

### Changes

- marks the project as `Archived` in the website catalog and root README;
- replaces the feature-oriented description with a historical/migration notice;
- adds an explicit warning to the image README;
- removes the image from the manual Docker Hub publish selector and reusable publish allow-list;
- keeps Dockerfile linting, Buildx checks, and historical AMD64 build validation so the archived artifact does not silently rot;
- updates the image publishing policy to distinguish publishable images from historical ones.

## Verification

- archived image still passes `docker buildx build --check`;
- AMD64 image completes a local build from the pinned historical submodule;
- Astro check and seven-page production build pass;
- npm production audit reports 0 vulnerabilities;
- workflow files pass actionlint;
- documentation links pass.

## Publishing impact

No Docker image is published or deleted. Existing Docker Hub tags remain available for current users, but the project can no longer be selected by the maintained-image publishing workflow.
