### PR TITLE
feat(maddy): upgrade image to v0.9.5

### DIFF
--- a/images/maddy/Dockerfile
+++ b/images/maddy/Dockerfile
@@ -1,33 +1,37 @@
-FROM golang:1.17-alpine AS build-env
+FROM golang:1.23-alpine AS build
 
-RUN set -ex ;\
-    apk upgrade --no-cache --available ;\
-    apk add --no-cache bash git build-base
+ARG MADDY_VERSION=v0.9.5
+ARG ADDITIONAL_BUILD_TAGS=""
 
-WORKDIR /maddy
-ADD ./maddy ./
-ENV LDFLAGS=-static
+RUN apk add --no-cache build-base
+
+WORKDIR /src
+COPY ./maddy/go.mod ./maddy/go.sum ./
 RUN go mod download
-RUN mkdir -p /pkg/data
-COPY ./maddy/maddy.conf /pkg/data/maddy.conf
-# Monkey-patch config to use environment.
-RUN sed -Ei 's!\$\(hostname\) = .+!$(hostname) = {env:MADDY_HOSTNAME}!' /pkg/data/maddy.conf
-RUN sed -Ei 's!\$\(primary_domain\) = .+!$(primary_domain) = {env:MADDY_DOMAIN}!' /pkg/data/maddy.conf
-RUN sed -Ei 's!^tls .+!tls file /data/tls_cert.pem /data/tls_key.pem!' /pkg/data/maddy.conf
+COPY ./maddy ./
 
-RUN ./build.sh --builddir /tmp --destdir /pkg/ --tags docker build install
+RUN ./build.sh \
+      --version "${MADDY_VERSION}" \
+      --builddir /tmp/build \
+      --destdir /tmp/package/ \
+      --tags "docker ${ADDITIONAL_BUILD_TAGS}" \
+      build install
 
-FROM alpine:latest
-LABEL maintainer="chasing0806@gmail.com"
-LABEL org.opencontainers.image.source=https://github.com/foxcpp/maddy
+FROM alpine:3.21.2
 
-RUN set -ex ;\
-    apk upgrade --no-cache --available ;\
-    apk --no-cache add ca-certificates
-COPY --from=build-env /pkg/data/maddy.conf /data/maddy.conf
-COPY --from=build-env /pkg/usr/local/bin/maddy /pkg/usr/local/bin/maddyctl /bin/
+ARG MADDY_VERSION=v0.9.5
+LABEL org.opencontainers.image.title="Maddy Mail Server" \
+      org.opencontainers.image.description="Composable all-in-one mail server" \
+      org.opencontainers.image.source="https://github.com/enwaiax/awesome-docker" \
+      org.opencontainers.image.version="${MADDY_VERSION}" \
+      org.opencontainers.image.licenses="GPL-3.0"
 
+RUN apk add --no-cache ca-certificates
 
-EXPOSE 25 143 993 587 465
+COPY --from=build /tmp/package/usr/local/bin/maddy /bin/maddy
+COPY ./maddy/maddy.conf.docker /data/maddy.conf
+
+EXPOSE 25 143 465 587 993
 VOLUME ["/data"]
 ENTRYPOINT ["/bin/maddy", "-config", "/data/maddy.conf"]
+CMD ["run"]

--- a/images/maddy/README.md
+++ b/images/maddy/README.md
@@ -1,5 +1,7 @@
 # maddy
 
+> This image tracks the pinned upstream release **Maddy v0.9.5** and supports AMD64 and ARM64.
+
 GitHub [enwaiax/awesome-docker](https://github.com/enwaiax/awesome-docker/tree/main/images/maddy)
 Docker [enwaiax/maddy](https://hub.docker.com/r/enwaiax/maddy)
 
@@ -33,15 +35,16 @@ docker volume create maddydata
 
 #### 2. 创建 tls 证书
 
-申请证书步骤略过，将证书 copy 并重命为`tls_key.pem`和`tls_cert.pem`到 volume 目录
+申请证书步骤略过。将证书链和私钥分别保存到 volume 中的 `tls/fullchain.pem` 与 `tls/privkey.pem`：
 
 ```shell
 # docker volume 目录
 cd $(docker volume inspect maddydata --format '{{.Mountpoint}}')
 
 # 拷贝并重命名证书到当前目录
-cp /etc/letsencrypt/live/mx1.example.org/cert.pem tls_cert.pem
-cp /etc/letsencrypt/live/mx1.example.org/privkey.pem tls_key.pem
+mkdir -p tls
+cp /etc/letsencrypt/live/mx1.example.org/fullchain.pem tls/fullchain.pem
+cp /etc/letsencrypt/live/mx1.example.org/privkey.pem tls/privkey.pem
 ```
 
 #### 3. 设置 hostname 和 domainname
@@ -60,7 +63,7 @@ docker run -d --name maddy \
   -e MADDY_HOSTNAME=$MADDY_HOSTNAME -e MADDY_DOMAIN=$MADDY_DOMAIN \
   -v maddydata:/data \
   -p 25:25 -p 143:143 -p 465:465 -p 587:587 -p 993:993 \
-  enwaiax/maddy:latest
+  enwaiax/maddy:0.9.5
 ```
 
 ##### 4.2 使用 Docker Compose 创建
@@ -106,8 +109,8 @@ default._domainkey.example.org   TXT    "v=DKIM1; k=ed25519; p=nAcUUozPlhc4VPhp7
 
 ```shell
 docker exec -it maddy sh
-maddyctl creds create postmaster@example.org
-maddyctl imap-acct create postmaster@example.org
+maddy creds create postmaster@example.org
+maddy imap-acct create postmaster@example.org
 ```
 
 ### 备份

--- a/images/maddy/docker-compose.yml
+++ b/images/maddy/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.9'
 services:
   maddy:
-    image: enwaiax/maddy
+    image: enwaiax/maddy:0.9.5
     container_name: maddy
     restart: unless-stopped
     environment:
@@ -12,6 +12,7 @@ services:
     ports:
       - "25:25"
       - "143:143"
+      - "465:465"
       - "587:587"
       - "993:993"
     logging:

--- a/site/src/data/projects.ts
+++ b/site/src/data/projects.ts
@@ -31,7 +31,7 @@ export const projects: Project[] = [
     name: 'Maddy Mail Server',
     eyebrow: 'Communication stack',
     summary: '一体化、低维护的个人邮件服务器。',
-    description: '用一个轻量守护进程替代 Postfix、Dovecot、OpenDKIM 等传统组合，并提供清晰的持久化、TLS 与 DNS 部署路径。',
+    description: '基于上游 Maddy v0.9.5，用一个轻量守护进程替代 Postfix、Dovecot、OpenDKIM 等传统组合，并提供清晰的持久化、TLS 与 DNS 部署路径。',
     category: '通信服务',
     status: 'maintained',
     statusLabel: 'Maintained',
@@ -52,7 +52,7 @@ export const projects: Project[] = [
   -v maddydata:/data \\
   -p 25:25 -p 143:143 -p 465:465 \\
   -p 587:587 -p 993:993 \\
-  enwaiax/maddy:latest`,
+  enwaiax/maddy:0.9.5`,
     compose: 'images/maddy/docker-compose.yml',
     notes: ['部署前确认 25 端口可用', '生产环境必须配置 TLS、SPF、DKIM 与 DMARC', '数据集中保存在 maddydata volume'],
   },


### PR DESCRIPTION
## Summary

Upgrades the maintained Maddy image from the pinned 2022-era v0.5.4 snapshot to the upstream **v0.9.5** release.

### Image

- updates the Maddy submodule to the exact `v0.9.5` tag (`58e8a114…`);
- moves the builder to Go 1.23 and the runtime to Alpine 3.21.2;
- uses the upstream Docker configuration instead of patching `maddy.conf` with `sed`;
- injects the explicit `v0.9.5` version into `build.sh`, so image builds do not depend on unavailable submodule Git metadata;
- adds OCI metadata labels and preserves optional upstream build tags;
- adopts the current single-binary management command (`maddy creds`, `maddy imap-acct`).

### Deployment documentation

- pins examples and Compose to `enwaiax/maddy:0.9.5`;
- documents the current TLS paths: `/data/tls/fullchain.pem` and `/data/tls/privkey.pem`;
- restores the missing port 465 mapping in Compose;
- updates the website catalog to show the pinned upstream release.

## Verification

- Dockerfile passes Buildx checks and Hadolint error threshold;
- Compose configuration parses successfully;
- AMD64 image builds and reports:

```text
v0.9.5 linux/amd64 go1.23.12
```

- OCI labels, entrypoint, and `run` command were inspected;
- volume initialization installs the upstream Docker config with environment-driven hostname/domain and current TLS paths;
- management subcommands `creds` and `imap-acct` are present;
- an actual AMD64 + ARM64 OCI image build completed, and the exported index contains both `linux/amd64` and `linux/arm64`;
- Astro check/build, npm audit, and documentation links pass.

## Publishing impact

This PR does not publish Docker Hub tags. After merge, run the manual supply-chain workflow on `main` with `publish: false` first. A separate explicit decision is still required before publishing `0.9.5` or replacing `latest`.
