### PR TITLE
docs: standardize image deployment guides

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -73,6 +73,10 @@ jobs:
 
       - name: Validate Compose file
         if: hashFiles(format('images/{0}/docker-compose.yml', matrix.project)) != ''
+        env:
+          ARIA2_RPC_SECRET: ci-validation-only
+          MADDY_HOSTNAME: mx.example.test
+          MADDY_DOMAIN: example.test
         run: docker compose -f "images/${{ matrix.project }}/docker-compose.yml" config -q
 
   website:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,6 +9,8 @@ on:
       - '.github/workflows/builder.yaml'
       - '.github/workflows/image-build.yml'
       - '.github/ISSUE_TEMPLATE/**'
+      - 'docs/image-guide-template.md'
+      - 'scripts/validate-image-guides.py'
       - 'images/maddy/**'
       - 'images/download-bot/**'
       - 'images/netease-cloud-music-tasks/**'
@@ -30,6 +32,15 @@ permissions:
   contents: read
 
 jobs:
+  image-guides:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Validate image guide contract
+        run: python3 scripts/validate-image-guides.py
+
   dockerfiles:
     runs-on: ubuntu-latest
     strategy:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ images/<project>/
 └── config/              # 仅放不含凭据的示例配置
 ```
 
-README 至少说明：
+README 必须基于 [`docs/image-guide-template.md`](docs/image-guide-template.md)，并通过 `scripts/validate-image-guides.py`。至少包含：
 
 1. 上游项目和许可证；
 2. 镜像地址、Tag 与支持架构；
@@ -38,10 +38,13 @@ README 至少说明：
 
 ```bash
 # 验证 Compose 文件
-docker compose -f <project>/docker-compose.yml config
+docker compose -f images/<project>/docker-compose.yml config
+
+# 验证 Guide 合同
+python3 scripts/validate-image-guides.py
 
 # 构建当前架构镜像
-docker build -t awesome-docker/<project>:test <project>
+docker build -t awesome-docker/<project>:test images/<project>
 
 # 验证网站
 cd site

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The new Astro website provides searchable project cards, consistent quick-start 
 - [Contributing guide](CONTRIBUTING.md)
 - [Security policy](SECURITY.md)
 - [Image publishing workflow](docs/image-publishing.md)
+- [Image Guide template](docs/image-guide-template.md)
 
 ## Repository layout
 

--- a/docs/image-guide-template.md
+++ b/docs/image-guide-template.md
@@ -1,0 +1,107 @@
+# <Image name>
+
+> **Lifecycle:** `Maintained | Community | Archived | Moved`
+> **Image:** `<namespace>/<image>:<version>`
+> **Architectures:** `<amd64, arm64, ...>`
+> **Last verified:** `YYYY-MM-DD`
+
+一句话说明镜像用途。Maintained/Community 指南面向部署；Archived/Moved 指南面向现有用户维护和迁移，不应鼓励新部署。
+
+## Overview
+
+- **Upstream:** <URL>
+- **Docker Hub:** <URL>
+- **Source directory:** <URL>
+- **Recommended for new deployments:** `Yes | No`
+
+说明适用场景、不适用场景、上游与本仓库的关系。
+
+## Prerequisites
+
+列出 Docker / Docker Compose、端口、域名、证书、CPU 架构、磁盘和第三方账号等要求。
+
+## Quick start
+
+### Docker CLI
+
+```bash
+# 使用明确版本，不要在可维护 Guide 中默认使用 latest
+docker run ... <image>:<version>
+```
+
+### Docker Compose
+
+```bash
+mkdir <project> && cd <project>
+curl -fsSLo compose.yaml <raw-compose-url>
+# 创建 .env 或其他必需配置
+docker compose config
+docker compose up -d
+```
+
+如果没有 Compose，明确写出原因。Archived/Moved 项目可将历史命令放在“Historical deployment”章节。
+
+## Configuration
+
+### Environment variables
+
+| Variable | Required | Default | Description |
+| --- | --- | --- | --- |
+| `EXAMPLE` | Yes | — | Example |
+
+### Ports
+
+| Port | Protocol | Required | Description |
+| --- | --- | --- | --- |
+| `8080` | TCP | Yes | Web UI |
+
+### Volumes
+
+| Host / volume | Container | Contains | Backup required |
+| --- | --- | --- | --- |
+| `./data` | `/data` | Application data | Yes |
+
+### Network and privileges
+
+说明 host networking、privileged、capabilities、设备映射和防火墙要求。没有特殊要求也要明确写出。
+
+## First-run verification
+
+```bash
+docker compose ps
+docker compose logs --tail=100
+```
+
+列出项目特定的版本、健康或登录验证命令，以及首次启动后必须修改的默认凭据。
+
+## Operations
+
+### Logs and status
+
+### Upgrade
+
+说明备份、拉取固定版本、重建和验证。Archived 项目应写明不提供升级保证。
+
+### Backup and restore
+
+明确哪些路径需要备份，并给出恢复步骤。不要直接建议删除数据目录。
+
+### Stop and uninstall
+
+区分“删除容器”和“删除持久化数据”，破坏性命令必须明确警告。
+
+## Security
+
+- 默认凭据和首次修改动作
+- Secret 的保存方式
+- TLS、端口和防火墙
+- 上游维护与已知风险
+- 禁止 `chmod -R 777`、硬编码 Token/密码、无提示删除数据
+
+## Troubleshooting
+
+至少列出两个常见故障的诊断命令与解决方向。
+
+## Lifecycle and known limitations
+
+说明当前生命周期、最后验证范围、发布限制及替代方案。构建成功不等于仍受支持或适合新部署。

--- a/images/download-bot/README.md
+++ b/images/download-bot/README.md
@@ -1,34 +1,206 @@
-# x-ui
+# Download Bot
 
-GitHub [enwaiax/awesome-docker](https://github.com/enwaiax/awesome-docker/tree/main/images/download-bot)
-Docker [enwaiax/download-bot](https://hub.docker.com/r/enwaiax/download-bot)
+> **Lifecycle:** `Community`
+> **Image:** `enwaiax/download-bot:latest`
+> **Architectures:** `amd64`, `arm64`
+> **Last verified:** `2026-08-15`
 
-> \*docker image support for AMD64 and ARM64
+Download Bot 通过 Telegram 管理 aria2 下载任务。本镜像可以继续使用，但上游最近一次代码更新较早，部署者需要自行维护 Bot Token、aria2 RPC Secret 和数据备份。
 
-## 简介
+## Overview
 
-基于 [gaowanliang/DownloadBot](https://github.com/gaowanliang/DownloadBot) 项目的 docker 镜像.
+- **Upstream:** https://github.com/gaowanliang/DownloadBot
+- **Docker Hub:** https://hub.docker.com/r/enwaiax/download-bot
+- **Source directory:** https://github.com/enwaiax/awesome-docker/tree/main/images/download-bot
+- **Recommended for new deployments:** `Yes, with community support expectations`
 
-## 部署
+容器本身不提供 aria2。Docker CLI 示例假设已有可访问的 aria2；Compose 示例同时启动 aria2 和 Download Bot。
 
-### 下载并配置 `config.json`
+## Prerequisites
 
+- Docker Engine 24+；Compose 部署需要 `docker compose` 插件。
+- 从 Telegram 的 BotFather 创建 Bot 并取得 Token。
+- 获取自己的 Telegram numeric user ID，并仅授权可信管理员。
+- 生成高强度 aria2 RPC Secret，例如：
+
+```bash
+openssl rand -hex 24
 ```
-curl -fsSL -o config.json https://raw.githubusercontent.com/enwaiax/awesome-docker/main/images/download-bot/config.json
+
+## Quick start
+
+### Docker CLI
+
+先复制示例配置：
+
+```bash
+mkdir download-bot && cd download-bot
+curl -fsSLo config.json https://raw.githubusercontent.com/enwaiax/awesome-docker/main/images/download-bot/config.json
+chmod 600 config.json
 ```
 
-### docker 部署
+编辑 `config.json`，至少替换 `aria2-server`、`aria2-key`、`bot-key` 和 `user-id`。然后连接已有 aria2：
 
-```
-docker run -itd --restart=on-failure \
-    -v $PWD/config.json:/root/config.json \
-    --name download-bot \
-    enwaiax/download-bot:latest
+```bash
+docker run -d \
+  --name download-bot \
+  --restart unless-stopped \
+  -v "$PWD/config.json:/root/config.json:ro" \
+  -v "$PWD/downloads:/downloads" \
+  enwaiax/download-bot:latest
 ```
 
-### Docker Compose 与 aria2 一起部署
+如果 aria2 在另一个容器中，应让两个容器加入同一个自定义网络，并在配置中使用 aria2 服务名，不要依赖宿主机回环地址。
 
+### Docker Compose
+
+```bash
+mkdir download-bot && cd download-bot
+curl -fsSLo compose.yaml https://raw.githubusercontent.com/enwaiax/awesome-docker/main/images/download-bot/docker-compose.yml
+curl -fsSLo config.json https://raw.githubusercontent.com/enwaiax/awesome-docker/main/images/download-bot/config.json
+cat > .env <<EOF
+ARIA2_RPC_SECRET=$(openssl rand -hex 24)
+TZ=Asia/Shanghai
+EOF
+chmod 600 .env config.json
 ```
-curl -fsSL -o compose.yaml https://raw.githubusercontent.com/enwaiax/awesome-docker/main/images/download-bot/docker-compose.yml
-docker compose -f compose.yaml up -d
+
+将 `.env` 中的 `ARIA2_RPC_SECRET` 同步填入 `config.json` 的 `aria2-key`，并将 aria2 地址设为：
+
+```json
+"aria2-server": "ws://aria2:6800/jsonrpc"
 ```
+
+再填入 Telegram 凭据并启动：
+
+```bash
+docker compose config
+docker compose up -d
+```
+
+## Configuration
+
+### Environment variables
+
+Download Bot 自身读取 `/root/config.json`；Compose 中的环境变量主要配置 aria2。
+
+| Variable | Required | Default | Description |
+| --- | --- | --- | --- |
+| `ARIA2_RPC_SECRET` | Yes | — | aria2 RPC Secret，必须与 `config.json` 的 `aria2-key` 一致 |
+| `PUID` / `PGID` | No | `65534` | aria2 写入下载目录时使用的 UID/GID |
+| `TZ` | No | `Asia/Shanghai` | aria2 容器时区 |
+
+`config.json` 关键字段：
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `aria2-server` | Yes | aria2 WebSocket RPC URL |
+| `aria2-key` | Yes | aria2 RPC Secret |
+| `bot-key` | Yes | Telegram Bot Token |
+| `user-id` | Yes | 允许管理 Bot 的 Telegram user ID，可按上游格式配置多个用户 |
+| `downloadFolder` | Yes | Bot 与 aria2 共同看到的下载路径，应为 `/downloads` |
+
+### Ports
+
+| Port | Protocol | Required | Description |
+| --- | --- | --- | --- |
+| `6800` | TCP | Compose only | aria2 RPC；不要暴露到公网，优先仅在 Docker 网络内使用 |
+| `6888` | TCP/UDP | Optional | aria2 BitTorrent 监听端口 |
+
+Download Bot 本身不监听入站 Web 端口。
+
+### Volumes
+
+| Host / volume | Container | Contains | Backup required |
+| --- | --- | --- | --- |
+| `./config.json` | `/root/config.json` | Telegram Token、管理员和 RPC 配置 | Yes, encrypted |
+| `./downloads` | `/downloads` | 下载内容 | As needed |
+| `./aria2-config` | `/config` | aria2 状态与配置 | Recommended |
+
+### Network and privileges
+
+不需要 privileged 或 host network。Compose 使用默认隔离网络；若无需从宿主机访问 RPC，可删除 `6800:6800` 映射以缩小攻击面。
+
+## First-run verification
+
+```bash
+docker compose ps
+docker compose logs --tail=100 aria2
+docker compose logs --tail=100 download-bot
+```
+
+在 Telegram 中向 Bot 发送 `/start` 或上游支持的帮助命令。确认未授权用户不能管理任务，并创建一个小型测试下载验证 `/downloads` 映射一致。
+
+## Operations
+
+### Logs and status
+
+```bash
+docker compose ps
+docker compose logs -f --tail=200 download-bot
+docker compose logs -f --tail=200 aria2
+```
+
+### Upgrade
+
+1. 备份 `config.json`、`.env` 和 `aria2-config`。
+2. 检查上游/镜像变更；当前仅提供 `latest`，更新前应记录现有 digest：
+
+```bash
+docker image inspect enwaiax/download-bot:latest --format '{{index .RepoDigests 0}}'
+```
+
+3. 执行 `docker compose pull && docker compose up -d`。
+4. 验证 Bot 授权、RPC 连接和测试下载。若失败，使用记录的 digest 回滚。
+
+### Backup and restore
+
+停止服务后备份配置：
+
+```bash
+docker compose down
+tar -czf download-bot-backup.tgz config.json .env aria2-config
+```
+
+恢复时解压到同一目录，检查权限后运行 `docker compose config` 和 `docker compose up -d`。下载数据是否备份由业务需求决定。
+
+### Stop and uninstall
+
+```bash
+docker compose down
+```
+
+该命令保留 bind-mounted 配置和下载文件。确认不再需要且已有备份后，再手动删除目录；不要把删除配置和普通卸载混为一谈。
+
+## Security
+
+- `bot-key`、`aria2-key` 和 `.env` 都是 Secret，权限设为 `600`，禁止提交 Git。
+- 不使用示例值作为 RPC Secret；每次泄露后同时轮换 `.env` 和 `config.json`。
+- 尽量不将 6800 暴露到公网；必须远程访问时使用防火墙、VPN 或反向代理认证。
+- `user-id` 只允许可信管理员；Bot Token 泄露后立即在 BotFather 撤销。
+- 下载内容是不可信输入，避免自动执行或由高权限用户打开。
+
+## Troubleshooting
+
+### Bot 无法连接 aria2
+
+```bash
+docker compose exec download-bot sh -c 'cat /root/config.json'
+docker compose logs --tail=200 aria2 download-bot
+```
+
+检查服务地址是否为 `ws://aria2:6800/jsonrpc`、Secret 是否一致，以及两个服务是否在同一个 Compose 网络。
+
+### Bot 没有响应
+
+检查 Bot Token、Telegram 网络连通性和 `user-id`。不要将完整配置粘贴到公开 Issue；先对 Token 和 user ID 脱敏。
+
+### 下载文件不可写
+
+检查 `PUID`、`PGID` 和宿主机 `downloads` 权限。使用最小必要权限，不要通过递归开放所有用户写权限来绕过问题。
+
+## Lifecycle and known limitations
+
+- 生命周期为 Community，上游最近更新较早，没有承诺的响应时间。
+- 当前 Docker Hub 仅使用浮动 `latest`；发布固定版本前，升级应保留旧 digest 以便回滚。
+- 本 Guide 验证 AMD64 构建、Compose 配置和目录映射，不保证第三方 aria2 镜像或 Telegram 服务长期兼容。

--- a/images/download-bot/docker-compose.yml
+++ b/images/download-bot/docker-compose.yml
@@ -1,39 +1,41 @@
-version: "3.8"
-
 services:
-  Aria2-Pro:
-    container_name: aria2-pro
-    image: p3terx/aria2-pro
+  aria2:
+    image: p3terx/aria2-pro:latest
+    restart: unless-stopped
     environment:
-      - PUID=65534
-      - PGID=65534
-      - UMASK_SET=022
-      - RPC_SECRET=P3TERX
-      - RPC_PORT=6800
-      - LISTEN_PORT=6888
-      - DISK_CACHE=64M
-      - IPV6_MODE=false
-      - UPDATE_TRACKERS=true
-      - TZ=Asia/Shanghai
-      - SPECIAL_MODE=rclone
+      PUID: ${PUID:-65534}
+      PGID: ${PGID:-65534}
+      UMASK_SET: "022"
+      RPC_SECRET: ${ARIA2_RPC_SECRET:?set ARIA2_RPC_SECRET}
+      RPC_PORT: "6800"
+      LISTEN_PORT: "6888"
+      DISK_CACHE: 64M
+      IPV6_MODE: "false"
+      UPDATE_TRACKERS: "true"
+      TZ: ${TZ:-Asia/Shanghai}
     volumes:
-      - ${PWD}/aria2-config:/config
-      - ${PWD}/aria2-downloads:/downloads
-    network_mode: host
-    restart: unless-stopped
+      - ./aria2-config:/config
+      - ./downloads:/downloads
+    ports:
+      - "6800:6800"
+      - "6888:6888"
+      - "6888:6888/udp"
     logging:
       driver: json-file
       options:
-        max-size: 1m
+        max-size: "10m"
+        max-file: "3"
 
-  DownloadBot:
-    container_name: download-bot
+  download-bot:
     image: enwaiax/download-bot:latest
-    volumes:
-      - ${PWD}/config.json:/root/config.json
-      - ${PWD}/aria2-downloads:/downloads
     restart: unless-stopped
+    depends_on:
+      - aria2
+    volumes:
+      - ./config.json:/root/config.json:ro
+      - ./downloads:/downloads
     logging:
       driver: json-file
       options:
-        max-size: 1m
+        max-size: "10m"
+        max-file: "3"

--- a/images/firefox-send/README.md
+++ b/images/firefox-send/README.md
@@ -1,0 +1,123 @@
+# Firefox Send historical deployment
+
+> **Lifecycle:** `Archived`
+> **Image:** `enwaiax/firefox_send:plus` (historical)
+> **Architectures:** `amd64` (historical)
+> **Last verified:** `2026-08-15`
+
+> [!WARNING]
+> Mozilla Send 上游已归档，本仓库不构建或发布该镜像。以下内容只用于识别旧实例、导出必要数据和迁移，不建议新部署。
+
+## Overview
+
+- **Archived upstream:** https://github.com/mozilla/send
+- **Source directory:** https://github.com/enwaiax/awesome-docker/tree/main/images/firefox-send
+- **Recommended for new deployments:** `No`
+
+旧 Compose 运行 Send 与 Redis。由于应用和依赖均不再维护，公开文件上传服务会面临较高滥用与漏洞风险。
+
+## Prerequisites
+
+只在隔离环境中维护历史实例。需要现有 Compose、Redis 数据、应用配置、反向代理配置和上传数据保留策略。
+
+## Quick start
+
+不提供新部署快速开始。为方便现有用户识别，历史启动方式为：
+
+```bash
+cd images/firefox-send
+docker compose config
+docker compose up -d
+```
+
+运行前必须审查镜像来源、网络暴露和数据需求。
+
+## Configuration
+
+### Environment variables
+
+| Variable | Required | Default | Description |
+| --- | --- | --- | --- |
+| `REDIS_HOST` | Yes | `redis` | Send 使用的 Redis 服务名 |
+
+其他应用设置以归档上游源码为准，本仓库不维护配置兼容性。
+
+### Ports
+
+| Port | Protocol | Required | Description |
+| --- | --- | --- | --- |
+| `1443` | TCP | Historical | Send Web 服务；不应未经认证和 TLS 直接暴露公网 |
+
+### Volumes
+
+旧 Compose 没有定义 Redis 持久化或上传数据 Volume，因此容器重建可能丢失状态。这也是不建议继续部署的原因之一。
+
+### Network and privileges
+
+不需要 privileged 或 host network。历史 `links` 配置已被 Compose 网络取代，但这不代表应用本身重新获得安全支持。
+
+## First-run verification
+
+```bash
+docker compose ps
+docker compose logs --tail=200 web redis
+```
+
+仅在隔离网络进行验证，不上传敏感文件。
+
+## Operations
+
+### Logs and status
+
+```bash
+docker compose logs -f --tail=200 web redis
+```
+
+### Upgrade
+
+没有受支持的升级路径。不要把更换浮动 Redis 或社区 Fork 当作本项目官方升级。
+
+### Backup and restore
+
+先检查实际容器 Mount：
+
+```bash
+docker inspect firefox-send-web-1 --format '{{json .Mounts}}'
+docker inspect firefox-send-redis-1 --format '{{json .Mounts}}'
+```
+
+旧 Compose 默认没有持久化声明；可迁移的数据取决于实例曾经做过的自定义配置。
+
+### Stop and uninstall
+
+```bash
+docker compose down
+```
+
+如果存在自定义 Volume，先导出并验证备份，再决定是否删除。
+
+## Security
+
+- 不向公网开放未经维护的上传服务。
+- 历史镜像和 Redis 依赖可能包含未修复漏洞。
+- 不上传隐私、凭据或业务文件进行测试。
+- 停用实例后清理 DNS、反向代理、对象存储和残留数据。
+
+## Troubleshooting
+
+### Web 服务无法连接 Redis
+
+```bash
+docker compose logs --tail=200 web redis
+docker compose exec web getent hosts redis
+```
+
+### 重建后数据消失
+
+旧 Compose 没有 Redis 持久化 Volume。检查是否存在自定义 Mount；若没有，容器层数据通常无法可靠恢复。
+
+## Lifecycle and known limitations
+
+- 生命周期为 Archived，上游与本仓库镜像均不再维护。
+- 没有新部署、升级、安全修复或数据恢复保证。
+- 迁移时优先选择仍受维护、具备清晰加密和保留策略的文件分享方案。

--- a/images/firefox-send/docker-compose.yml
+++ b/images/firefox-send/docker-compose.yml
@@ -1,14 +1,24 @@
-version: "3.8"
 services:
   web:
     image: enwaiax/firefox_send:plus
-    links:
+    restart: unless-stopped
+    depends_on:
       - redis
     ports:
-      - "1443:1443"
-    restart: unless-stopped
+      - "127.0.0.1:1443:1443"
     environment:
-      - REDIS_HOST=redis
+      REDIS_HOST: redis
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
   redis:
     image: redis:alpine
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/images/maddy/Dockerfile
+++ b/images/maddy/Dockerfile
@@ -1,33 +1,37 @@
-FROM golang:1.17-alpine AS build-env
+FROM golang:1.23-alpine AS build
 
-RUN set -ex ;\
-    apk upgrade --no-cache --available ;\
-    apk add --no-cache bash git build-base
+ARG MADDY_VERSION=v0.9.5
+ARG ADDITIONAL_BUILD_TAGS=""
 
-WORKDIR /maddy
-ADD ./maddy ./
-ENV LDFLAGS=-static
+RUN apk add --no-cache build-base
+
+WORKDIR /src
+COPY ./maddy/go.mod ./maddy/go.sum ./
 RUN go mod download
-RUN mkdir -p /pkg/data
-COPY ./maddy/maddy.conf /pkg/data/maddy.conf
-# Monkey-patch config to use environment.
-RUN sed -Ei 's!\$\(hostname\) = .+!$(hostname) = {env:MADDY_HOSTNAME}!' /pkg/data/maddy.conf
-RUN sed -Ei 's!\$\(primary_domain\) = .+!$(primary_domain) = {env:MADDY_DOMAIN}!' /pkg/data/maddy.conf
-RUN sed -Ei 's!^tls .+!tls file /data/tls_cert.pem /data/tls_key.pem!' /pkg/data/maddy.conf
+COPY ./maddy ./
 
-RUN ./build.sh --builddir /tmp --destdir /pkg/ --tags docker build install
+RUN ./build.sh \
+      --version "${MADDY_VERSION}" \
+      --builddir /tmp/build \
+      --destdir /tmp/package/ \
+      --tags "docker ${ADDITIONAL_BUILD_TAGS}" \
+      build install
 
-FROM alpine:latest
-LABEL maintainer="chasing0806@gmail.com"
-LABEL org.opencontainers.image.source=https://github.com/foxcpp/maddy
+FROM alpine:3.21.2
 
-RUN set -ex ;\
-    apk upgrade --no-cache --available ;\
-    apk --no-cache add ca-certificates
-COPY --from=build-env /pkg/data/maddy.conf /data/maddy.conf
-COPY --from=build-env /pkg/usr/local/bin/maddy /pkg/usr/local/bin/maddyctl /bin/
+ARG MADDY_VERSION=v0.9.5
+LABEL org.opencontainers.image.title="Maddy Mail Server" \
+      org.opencontainers.image.description="Composable all-in-one mail server" \
+      org.opencontainers.image.source="https://github.com/enwaiax/awesome-docker" \
+      org.opencontainers.image.version="${MADDY_VERSION}" \
+      org.opencontainers.image.licenses="GPL-3.0"
 
+RUN apk add --no-cache ca-certificates
 
-EXPOSE 25 143 993 587 465
+COPY --from=build /tmp/package/usr/local/bin/maddy /bin/maddy
+COPY ./maddy/maddy.conf.docker /data/maddy.conf
+
+EXPOSE 25 143 465 587 993
 VOLUME ["/data"]
 ENTRYPOINT ["/bin/maddy", "-config", "/data/maddy.conf"]
+CMD ["run"]

--- a/images/maddy/README.md
+++ b/images/maddy/README.md
@@ -1,5 +1,7 @@
 # maddy
 
+> This image tracks the pinned upstream release **Maddy v0.9.5** and supports AMD64 and ARM64.
+
 GitHub [enwaiax/awesome-docker](https://github.com/enwaiax/awesome-docker/tree/main/images/maddy)
 Docker [enwaiax/maddy](https://hub.docker.com/r/enwaiax/maddy)
 
@@ -33,15 +35,16 @@ docker volume create maddydata
 
 #### 2. 创建 tls 证书
 
-申请证书步骤略过，将证书 copy 并重命为`tls_key.pem`和`tls_cert.pem`到 volume 目录
+申请证书步骤略过。将证书链和私钥分别保存到 volume 中的 `tls/fullchain.pem` 与 `tls/privkey.pem`：
 
 ```shell
 # docker volume 目录
 cd $(docker volume inspect maddydata --format '{{.Mountpoint}}')
 
 # 拷贝并重命名证书到当前目录
-cp /etc/letsencrypt/live/mx1.example.org/cert.pem tls_cert.pem
-cp /etc/letsencrypt/live/mx1.example.org/privkey.pem tls_key.pem
+mkdir -p tls
+cp /etc/letsencrypt/live/mx1.example.org/fullchain.pem tls/fullchain.pem
+cp /etc/letsencrypt/live/mx1.example.org/privkey.pem tls/privkey.pem
 ```
 
 #### 3. 设置 hostname 和 domainname
@@ -60,7 +63,7 @@ docker run -d --name maddy \
   -e MADDY_HOSTNAME=$MADDY_HOSTNAME -e MADDY_DOMAIN=$MADDY_DOMAIN \
   -v maddydata:/data \
   -p 25:25 -p 143:143 -p 465:465 -p 587:587 -p 993:993 \
-  enwaiax/maddy:latest
+  enwaiax/maddy:0.9.5
 ```
 
 ##### 4.2 使用 Docker Compose 创建
@@ -106,8 +109,8 @@ default._domainkey.example.org   TXT    "v=DKIM1; k=ed25519; p=nAcUUozPlhc4VPhp7
 
 ```shell
 docker exec -it maddy sh
-maddyctl creds create postmaster@example.org
-maddyctl imap-acct create postmaster@example.org
+maddy creds create postmaster@example.org
+maddy imap-acct create postmaster@example.org
 ```
 
 ### 备份

--- a/images/maddy/README.md
+++ b/images/maddy/README.md
@@ -1,130 +1,230 @@
-# maddy
+# Maddy Mail Server
 
-> This image tracks the pinned upstream release **Maddy v0.9.5** and supports AMD64 and ARM64.
+> **Lifecycle:** `Maintained`
+> **Image:** `enwaiax/maddy:0.9.5`
+> **Architectures:** `amd64`, `arm64`
+> **Last verified:** `2026-08-15`
 
-GitHub [enwaiax/awesome-docker](https://github.com/enwaiax/awesome-docker/tree/main/images/maddy)
-Docker [enwaiax/maddy](https://hub.docker.com/r/enwaiax/maddy)
+Maddy 是一个可组合的一体化邮件服务器。本镜像固定到上游 Maddy v0.9.5，适合愿意自行维护 DNS、TLS、投递信誉和备份的自托管用户。
 
-> \*docker image support for AMD64 and ARM64
+## Overview
 
-## 简介
+- **Upstream:** https://github.com/foxcpp/maddy
+- **Docker Hub:** https://hub.docker.com/r/enwaiax/maddy
+- **Source directory:** https://github.com/enwaiax/awesome-docker/tree/main/images/maddy
+- **Recommended for new deployments:** `Yes`
 
-基于 [foxcpp/maddy](https://github.com/foxcpp/maddy) 项目的 docker 镜像.
+Maddy 用一个 Go 守护进程提供 SMTP、Submission、IMAP、DKIM、SPF、DMARC、DANE 和 MTA-STS 等能力。它降低了组件数量，但不会替代邮件系统运维：公网 25 端口、正确 DNS、反向解析、TLS 和投递信誉仍由部署者负责。
 
-Maddy 是一款用 Go 语言开发的邮件服务器，它实现了运行电子邮件服务器所需的所有功能。
+## Prerequisites
 
-Maddy 用一个具有统一配置和最低维护成本的守护进程取代了 Postfix、Dovecot、OpenDKIM、OpenSPF、OpenDMARC 等程序。
+- Docker Engine 24+；使用 Compose 时需要 `docker compose` 插件。
+- 公网服务器、固定 IP，以及可配置 A/AAAA、MX、PTR、SPF、DKIM、DMARC 的域名。
+- 云厂商允许入站和出站 TCP 25；Submission 使用 465/587，IMAP 使用 143/993。
+- TLS 证书链和私钥，分别放入 `/data/tls/fullchain.pem` 与 `/data/tls/privkey.pem`。
+- 至少为 `/data` 建立持久化和离机备份。
 
-通俗点讲就是部署特别方便, 资源占用少，非常适合个人使用的电子邮件服务器。
+检查出站 25 端口时，可运行：
 
-### 预置条件
-
-检查 25 端口是否开放
-
+```bash
+timeout 5 bash -c '</dev/tcp/smtp.gmail.com/25' && echo 'TCP 25 reachable'
 ```
-telnet smtp.aol.com 25
-```
 
-### 部署步骤
+## Quick start
 
-#### 1. 创建 docker volume
+### Docker CLI
 
-```
+```bash
 docker volume create maddydata
-```
 
-#### 2. 创建 tls 证书
-
-申请证书步骤略过。将证书链和私钥分别保存到 volume 中的 `tls/fullchain.pem` 与 `tls/privkey.pem`：
-
-```shell
-# docker volume 目录
-cd $(docker volume inspect maddydata --format '{{.Mountpoint}}')
-
-# 拷贝并重命名证书到当前目录
-mkdir -p tls
-cp /etc/letsencrypt/live/mx1.example.org/fullchain.pem tls/fullchain.pem
-cp /etc/letsencrypt/live/mx1.example.org/privkey.pem tls/privkey.pem
-```
-
-#### 3. 设置 hostname 和 domainname
-
-```
 export MADDY_HOSTNAME=mx1.example.org
 export MADDY_DOMAIN=example.org
-```
 
-#### 4. 创建 maddy 实例
-
-##### 4.1 使用 docker 创建
-
-```shell
-docker run -d --name maddy \
-  -e MADDY_HOSTNAME=$MADDY_HOSTNAME -e MADDY_DOMAIN=$MADDY_DOMAIN \
+docker run -d \
+  --name maddy \
+  --restart unless-stopped \
+  -e MADDY_HOSTNAME="$MADDY_HOSTNAME" \
+  -e MADDY_DOMAIN="$MADDY_DOMAIN" \
   -v maddydata:/data \
-  -p 25:25 -p 143:143 -p 465:465 -p 587:587 -p 993:993 \
+  -p 25:25 \
+  -p 143:143 \
+  -p 465:465 \
+  -p 587:587 \
+  -p 993:993 \
   enwaiax/maddy:0.9.5
 ```
 
-##### 4.2 使用 Docker Compose 创建
+首次启动会因为 TLS 文件尚未放入而失败，这是预期行为。使用临时容器将证书复制进 Volume，不要直接依赖 `/var/lib/docker/volumes` 的内部路径：
 
-```shell
+```bash
+docker run --rm \
+  -v maddydata:/data \
+  -v /etc/letsencrypt/live/mx1.example.org:/certs:ro \
+  --entrypoint sh \
+  enwaiax/maddy:0.9.5 \
+  -c 'mkdir -p /data/tls && cp /certs/fullchain.pem /data/tls/fullchain.pem && cp /certs/privkey.pem /data/tls/privkey.pem && chmod 600 /data/tls/privkey.pem'
+
+docker start maddy
+```
+
+### Docker Compose
+
+```bash
 mkdir maddy && cd maddy
-curl -fsSL -o compose.yaml https://raw.githubusercontent.com/enwaiax/awesome-docker/main/images/maddy/docker-compose.yml
-docker compose -f compose.yaml up -d
+curl -fsSLo compose.yaml https://raw.githubusercontent.com/enwaiax/awesome-docker/main/images/maddy/docker-compose.yml
+cat > .env <<'EOF'
+MADDY_HOSTNAME=mx1.example.org
+MADDY_DOMAIN=example.org
+EOF
+
+docker compose config
+docker compose up -d
 ```
 
-#### 5. 配置 DNS 记录解析
+证书仍需复制到 `maddydata` Volume 的 `tls/` 目录。
 
-```shell
-# A记录
-example.org   A     10.2.3.4
-example.org   AAAA  2001:beef::1
+## Configuration
 
-# MX记录
-example.org   MX    mx1.example.org.
-# 同时最好配置mx1.example.org的A记录
-mx1.example.org   A     10.2.3.4
-mx1.example.org   AAAA  2001:beef::1
+### Environment variables
 
-# SPF
-example.org     TXT   "v=spf1 mx ~all"
-mx1.example.org TXT   "v=spf1 mx ~all"
+| Variable | Required | Default | Description |
+| --- | --- | --- | --- |
+| `MADDY_HOSTNAME` | Yes | — | 邮件服务器 FQDN，例如 `mx1.example.org` |
+| `MADDY_DOMAIN` | Yes | — | 主邮件域，例如 `example.org` |
 
-# _dmarc
-_dmarc.example.org   TXT    "v=DMARC1; p=quarantine; ruf=mailto:postmaster@example.org"
+主配置位于 `/data/maddy.conf`。初始化后修改该文件前必须备份；环境变量只影响上游 Docker 默认配置中引用 `{env:...}` 的字段。
 
-# _mta-sts，_smtp.tls
-_mta-sts.example.org   TXT    "v=STSv1; id=1"
-_smtp._tls.example.org TXT    "v=TLSRPTv1;rua=mailto:postmaster@example.org"
+### Ports
 
-# _dmarc
-cd $(docker volume inspect maddydata --format '{{.Mountpoint}}')
-cat dkim_keys/*.dns
+| Port | Protocol | Required | Description |
+| --- | --- | --- | --- |
+| `25` | TCP | Yes | 入站 SMTP 和服务器间投递 |
+| `465` | TCP/TLS | Optional | 隐式 TLS Submission |
+| `587` | TCP | Recommended | STARTTLS Submission |
+| `143` | TCP | Optional | STARTTLS IMAP |
+| `993` | TCP/TLS | Recommended | 隐式 TLS IMAP |
 
-default._domainkey.example.org   TXT    "v=DKIM1; k=ed25519; p=nAcUUozPlhc4VPhp7hZl+owES7j7OlEv0laaDEDBAqg="
+只开放实际使用的端口，并在云安全组和主机防火墙中保持一致。
+
+### Volumes
+
+| Host / volume | Container | Contains | Backup required |
+| --- | --- | --- | --- |
+| `maddydata` | `/data` | 配置、SQLite 数据库、邮件、队列、DKIM、TLS | Yes |
+
+### Network and privileges
+
+镜像不需要 privileged、host network 或额外 Linux capabilities。默认 bridge 网络配合显式端口映射即可。
+
+## First-run verification
+
+```bash
+docker ps --filter name=maddy
+docker logs --tail=100 maddy
+docker exec maddy maddy version
+docker exec maddy maddy creds create postmaster@example.org
+docker exec maddy maddy imap-acct create postmaster@example.org
 ```
 
-#### 6. 创建邮件发送账户
+然后从 `/data/dkim_keys/*.dns` 获取 DKIM TXT 记录，并完成：
 
-```shell
-docker exec -it maddy sh
-maddy creds create postmaster@example.org
-maddy imap-acct create postmaster@example.org
+- `mx1.example.org` 的 A/AAAA 和 PTR；
+- `example.org` 指向 `mx1.example.org` 的 MX；
+- SPF、DKIM、DMARC；
+- 可选的 MTA-STS 与 TLS-RPT。
+
+不要照抄示例 DKIM 公钥；必须使用当前实例生成的记录。
+
+## Operations
+
+### Logs and status
+
+```bash
+docker logs --tail=200 -f maddy
+docker exec maddy maddy version
+docker stats maddy
 ```
 
-### 备份
+### Upgrade
 
-所有数据挂载在 volume 中，volum 路径为:
+1. 阅读目标 Maddy release notes。
+2. 完整备份 `/data`。
+3. 将镜像 Tag 改为明确版本，执行 `docker compose pull && docker compose up -d`。
+4. 验证版本、日志、SMTP Submission、IMAP 和队列状态。
+5. 不要跨版本复用不同版本容器执行管理命令。
 
+### Backup and restore
+
+停止写入后备份 Volume：
+
+```bash
+docker stop maddy
+docker run --rm -v maddydata:/data -v "$PWD:/backup" alpine:3.21.2 \
+  tar -C /data -czf /backup/maddydata.tgz .
+docker start maddy
 ```
-$ docker volume inspect maddydata --format '{{.Mountpoint}}'
-/var/lib/docker/volumes/maddydata/_data
-$ cd /var/lib/docker/volumes/maddydata/_data
 
+恢复到新 Volume：
+
+```bash
+docker volume create maddydata-restored
+docker run --rm -v maddydata-restored:/data -v "$PWD:/backup:ro" alpine:3.21.2 \
+  tar -C /data -xzf /backup/maddydata.tgz
 ```
 
-备份该目录即可
+先用临时容器验证恢复内容，再切换生产容器的 Volume。
 
-### 其他
-- [搭建webmail: Rainloop](rainloop/README.md)
+### Stop and uninstall
+
+```bash
+docker rm -f maddy
+```
+
+以上命令不会删除 `maddydata`。只有确认备份可恢复后，才可执行破坏性操作：
+
+```bash
+docker volume rm maddydata
+```
+
+## Security
+
+- 私钥权限应限制为仅容器内服务可读；不要提交证书、密码或数据库到 Git。
+- 账号密码通过交互式 `maddy creds create` 设置，不写入 Compose 或 shell history。
+- 将 143/587 配置为强制 STARTTLS，或仅使用 993/465。
+- 邮件服务器是高滥用风险服务；持续监控队列、认证失败、磁盘容量和异常外发。
+- 定期更新固定版本，升级前验证配置兼容性和备份。
+
+## Troubleshooting
+
+### 容器启动后立即退出
+
+```bash
+docker logs --tail=200 maddy
+docker run --rm -v maddydata:/data --entrypoint sh enwaiax/maddy:0.9.5 \
+  -c 'ls -l /data/tls /data/maddy.conf'
+```
+
+常见原因是 TLS 文件缺失、路径错误或 `MADDY_HOSTNAME` / `MADDY_DOMAIN` 未设置。
+
+### 外部邮件无法投递
+
+检查公网 TCP 25、PTR、MX、SPF、DKIM、DMARC，以及云厂商是否封锁出站 25。使用外部邮件测试服务验证，而不要仅依赖容器内端口监听。
+
+### 客户端无法登录
+
+检查账号是否同时存在于凭据和 IMAP 数据库，并检查 465/587、143/993 的 TLS 与防火墙配置：
+
+```bash
+docker logs --tail=200 maddy | grep -iE 'auth|imap|submission|tls'
+```
+
+## Archived add-ons
+
+- [RainLoop historical guide](rainloop/README.md) — archived, not recommended for new deployments.
+
+## Lifecycle and known limitations
+
+- 本 Guide 已针对 Maddy v0.9.5、AMD64 和 ARM64 构建进行验证。
+- IMAP 存储在上游仍标记为 beta；关键邮件系统应评估 Dovecot 等成熟存储方案。
+- 本仓库维护容器封装和部署说明，不替代上游安全公告、邮件投递运维和数据恢复演练。
+- 镜像发布前仍需通过 main 分支手动 dry run 和显式发布审批。

--- a/images/maddy/docker-compose.yml
+++ b/images/maddy/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.9'
 services:
   maddy:
-    image: enwaiax/maddy
+    image: enwaiax/maddy:0.9.5
     container_name: maddy
     restart: unless-stopped
     environment:
@@ -12,6 +12,7 @@ services:
     ports:
       - "25:25"
       - "143:143"
+      - "465:465"
       - "587:587"
       - "993:993"
     logging:

--- a/images/maddy/docker-compose.yml
+++ b/images/maddy/docker-compose.yml
@@ -1,12 +1,10 @@
-version: '3.9'
 services:
   maddy:
     image: enwaiax/maddy:0.9.5
-    container_name: maddy
     restart: unless-stopped
     environment:
-      - MADDY_HOSTNAME=$MADDY_HOSTNAME
-      - MADDY_DOMAIN=$MADDY_DOMAIN
+      MADDY_HOSTNAME: ${MADDY_HOSTNAME:?set MADDY_HOSTNAME}
+      MADDY_DOMAIN: ${MADDY_DOMAIN:?set MADDY_DOMAIN}
     volumes:
       - maddydata:/data
     ports:
@@ -23,5 +21,4 @@ services:
 
 volumes:
   maddydata:
-    driver: local
     name: maddydata

--- a/images/maddy/rainloop/README.md
+++ b/images/maddy/rainloop/README.md
@@ -1,45 +1,110 @@
-# 搭建 Rainloop
-## 简介
+# RainLoop historical webmail add-on
 
-RainLoop 是基于 WEB 的邮件服务器系统是一个免费开源的 PHP Web Mail 客户端系统应用工具，可以用一个界面管理多个帐号，该程序拥有简洁的界面和全面的功能，支持 SMTP+IMAP。
+> **Lifecycle:** `Archived`
+> **Recommended for new deployments:** `No`
+> **Last verified:** `2026-08-15`
 
-用来配合 maddy 可以非常方便的搭建一套完整的带 webmail 的电子邮件服务。
+> [!WARNING]
+> 此 RainLoop 组合使用过时的应用、PHP 和明文 HTTP 示例，已不再作为 Maddy 推荐组件。保留本页仅帮助旧实例备份和迁移。
 
-## 步骤
+## Overview
 
-### 1. 下载 rainloop 安装包
+历史方案通过 Nginx + PHP-FPM 提供 RainLoop Webmail，并连接外部 Maddy SMTP/IMAP。它不属于 Maddy 主镜像，也没有本仓库维护的安全更新。
 
-```
-mkdir rainloop && cd rainloop
-wget -q https://www.rainloop.net/repository/webmail/rainloop-community-latest.zip
-unzip rainloop-community-latest.zip -d rainloop
-chmod -R 777 rainloop
-```
+## Prerequisites
 
-### 2. 下载 Docker Compose 文件
+只在隔离环境维护旧实例。需要现有 RainLoop 文件、应用配置、用户自定义、反向代理和 TLS 配置。
 
-```
-curl -fsSL -o compose.yaml https://raw.githubusercontent.com/enwaiax/awesome-docker/main/images/maddy/rainloop/docker-compose.yml
-```
+## Quick start
 
-### 3. 下载 nginx 配置文件
+不提供新部署命令。现有用户可以用以下命令识别旧服务：
 
-```
-curl -fsSLO https://raw.githubusercontent.com/enwaiax/awesome-docker/main/images/maddy/rainloop/rainloop.conf
+```bash
+docker compose -f compose.yaml config
+docker compose -f compose.yaml ps
+docker compose -f compose.yaml logs --tail=200
 ```
 
-### 4. 拉起 docker
+不要重新执行旧教程中的宽松权限或默认密码步骤。
 
+## Configuration
+
+### Environment variables
+
+历史 Compose 未定义环境变量契约。
+
+### Ports
+
+旧配置将 Nginx HTTP 暴露在 TCP 80。它不应直接用于公网，应由受维护的 TLS 反向代理和 Webmail 替代方案接管。
+
+### Volumes
+
+| Host | Container | Contains | Backup |
+| --- | --- | --- | --- |
+| `./rainloop` | Nginx/PHP Web root | 应用、配置、插件和用户设置 | Required |
+| `./rainloop.conf` | Nginx config | Web server routing | Recommended |
+
+### Network and privileges
+
+不需要 privileged 或 host network。旧方案的风险主要来自过时应用、运行时和文件权限，而非 Docker capability。
+
+## First-run verification
+
+只验证现有实例：
+
+```bash
+docker compose ps
+docker compose logs --tail=200 nginx php
 ```
-docker compose -f compose.yaml up -d
+
+不要使用默认管理员凭据或真实邮箱密码进行公开测试。
+
+## Operations
+
+### Logs and status
+
+```bash
+docker compose logs -f --tail=200 nginx php
 ```
 
-### 5. 登录后台初始配置
+### Upgrade
 
-地址为：http://ip/?admin
-初始用户名密码为： admin/12345，请及时修改
-配置好搭建的 maddy 地址，访问 http://ip，使用 maddy 里创建的用户登录即可从网页端发送邮件
+不提供升级路径。应迁移到仍受维护的 Webmail 客户端，而不是替换单个 PHP Tag 后继续运行。
 
-### 6. 其他
+### Backup and restore
 
-也可使用 windows 客户端[thunderbird](https://www.thunderbird.net)
+```bash
+docker compose down
+tar -czf rainloop-backup.tgz rainloop rainloop.conf compose.yaml
+```
+
+在隔离环境恢复并导出必要设置，不要将旧实例重新暴露公网。
+
+### Stop and uninstall
+
+```bash
+docker compose down
+```
+
+确认迁移完成后再删除应用目录和反向代理配置。
+
+## Security
+
+- 禁止使用递归 world-writable 权限；按 Web 服务 UID/GID 设置最小权限。
+- 立即轮换历史默认管理员密码和曾保存在客户端中的邮箱凭据。
+- 不使用明文 HTTP 登录邮箱。
+- 旧 PHP RC/Alpine 组合和 RainLoop 本体均不再视为安全基线。
+
+## Troubleshooting
+
+### 页面返回 502
+
+检查 PHP-FPM 容器、Nginx upstream 配置和共享 Web root Mount。
+
+### 无法连接 Maddy
+
+核对 SMTP/IMAP 地址、TLS 端口和证书，不要通过关闭 TLS 验证解决问题。
+
+## Lifecycle and known limitations
+
+该附加方案已 Archived，不再由网站作为推荐项目展示。新部署应选择受维护的 Webmail，并单独完成安全评估、TLS 和备份设计。

--- a/images/maddy/rainloop/docker-compose.yml
+++ b/images/maddy/rainloop/docker-compose.yml
@@ -1,27 +1,25 @@
-version: '3.8'
 services:
+  nginx:
+    image: nginx:alpine
+    restart: on-failure
+    ports:
+      - "127.0.0.1:8080:80"
+    volumes:
+      - ./rainloop:/usr/share/nginx/html:ro
+      - ./rainloop.conf:/etc/nginx/conf.d/default.conf:ro
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
   php:
     image: php:8.1.6RC1-fpm-alpine3.15
-    container_name: php
     restart: on-failure
     volumes:
       - ./rainloop:/var/www/html
     logging:
       driver: json-file
       options:
-        max-size: "1m"
-        max-file: "10"
-  nginx:
-    image: nginx:alpine
-    container_name: nginx
-    restart: on-failure
-    volumes:
-      - ./rainloop:/usr/share/nginx/html
-      - ./rainloop.conf:/etc/nginx/conf.d/default.conf
-    ports:
-      - 80:80
-    logging:
-      driver: json-file
-      options:
-        max-size: "1m"
-        max-file: "10"
+        max-size: "10m"
+        max-file: "3"

--- a/images/netease-cloud-music-tasks/README.md
+++ b/images/netease-cloud-music-tasks/README.md
@@ -1,58 +1,130 @@
-# `netease-cloud-music-tasks`
+# Netease Music Tasks
+
+> **Lifecycle:** `Archived`
+> **Image:** `enwaiax/netease-cloud-music-tasks:latest`
+> **Architectures:** `amd64`, `arm64`
+> **Last verified:** `2026-08-15`
 
 > [!WARNING]
-> **Archived:** 上游仓库已归档，且本镜像自 2022 年起未再发布。本目录仅保留作历史和迁移参考，不建议用于新的生产部署。
+> 上游仓库已归档，且本镜像自 2022 年起未再发布。本目录仅供现有用户识别、备份和迁移，不建议新部署，也不提供安全或兼容性保证。
 
-GitHub [enwaiax/awesome-docker](https://github.com/enwaiax/awesome-docker/tree/main/images/netease-cloud-music-tasks)
-Docker [enwaiax/netease-cloud-music-tasks](https://hub.docker.com/r/enwaiax/netease-cloud-music-tasks)
+## Overview
 
->docker image support for AMD64 and ARM64
+- **Upstream:** https://github.com/chen310/NeteaseCloudMusicTasks
+- **Docker Hub:** https://hub.docker.com/r/enwaiax/netease-cloud-music-tasks
+- **Source directory:** https://github.com/enwaiax/awesome-docker/tree/main/images/netease-cloud-music-tasks
+- **Recommended for new deployments:** `No`
 
-## 简介
+历史功能包括签到、任务执行、多账号和消息推送。服务行为依赖第三方平台接口，归档后可能随时失效。
 
-基于 [chen310/NeteaseCloudMusicTasks](https://github.com/chen310/NeteaseCloudMusicTasks) 项目的 docker 镜像.
+## Prerequisites
 
-### 镜像介绍
+本项目不再建议部署。维护历史实例需要 Docker、原始 `config.json`、账号授权信息，以及对第三方服务条款和账号风险的理解。
 
-1. 签到领云贝
-2. 自动完成云贝任务，并领取云贝
-3. 打卡升级
-4. 刷指定歌曲的播放量
-5. 音乐人自动签到领取云豆
-6. 音乐人自动完成任务，并领取云豆
-7. 自动领取 vip 成长值（任务需自己完成）
-8. 多种推送方式
-9. 支持多账号
+## Quick start
 
-### 注册成为网易云音乐人
+不提供面向新用户的快速开始。下面命令只用于识别和临时恢复历史实例，运行前先审查配置和镜像：
 
-[<img src="https://s4.ax1x.com/2022/02/15/HRTJ5q.jpg" alt="HRTJ5q.jpg" style="zoom:35%;" />](https://imgtu.com/i/HRTJ5q)
-
-## 部署
-
-### 下载并配置 `config.json`
-
-```
-curl -fsSL -o config.json https://raw.githubusercontent.com/chen310/NeteaseCloudMusicTasks/main/config.json
+```bash
+docker run -d \
+  --name netease-cloud-music-tasks \
+  --restart on-failure \
+  -v "$PWD/config.json:/root/config.json:ro" \
+  enwaiax/netease-cloud-music-tasks:latest
 ```
 
-修改配置参考[配置说明](https://github.com/chen310/NeteaseCloudMusicTasks#%E4%BF%AE%E6%94%B9%E9%85%8D%E7%BD%AE)
+本项目没有维护中的 Compose 文件。不要为了方便而将账号凭据写进新的 Compose 仓库。
 
-### 随机时间执行
+## Configuration
 
-```
-docker run -itd --restart=on-failure \
-    -v $(pwd)/config.json:/root/config.json \
-    --name netease-cloud-music-tasks \
-    enwaiax/netease-cloud-music-tasks:latest
+### Environment variables
+
+| Variable | Required | Default | Description |
+| --- | --- | --- | --- |
+| `SCHEDULER_HOUR` | No | Upstream default | 历史定时执行小时 |
+| `SCHEDULER_MINUTE` | No | Upstream default | 历史定时执行分钟 |
+
+账号、Cookie、推送 Token 等主要位于 `config.json`，字段以归档上游源码为准。
+
+### Ports
+
+镜像不提供需要暴露的服务端口。
+
+### Volumes
+
+| Host / volume | Container | Contains | Backup required |
+| --- | --- | --- | --- |
+| `./config.json` | `/root/config.json` | 账号、Cookie、推送配置 | Yes, encrypted |
+
+### Network and privileges
+
+不需要 privileged、host network 或端口映射。容器需要访问第三方 API；网络访问不代表接口仍受支持。
+
+## First-run verification
+
+历史实例可通过以下命令检查：
+
+```bash
+docker ps --filter name=netease-cloud-music-tasks
+docker logs --tail=200 netease-cloud-music-tasks
 ```
 
-### 指定时间执行
+不要使用真实主账号测试未知或失效的自动化行为。
 
+## Operations
+
+### Logs and status
+
+```bash
+docker logs -f --tail=200 netease-cloud-music-tasks
 ```
-docker run -itd --restart=on-failure \
-    -v $(pwd)/config.json:/root/config.json \
-    -e "SCHEDULER_HOUR=8" -e "SCHEDULER_MINUTE=30" \
-    --name netease-cloud-music-tasks \
-    enwaiax/netease-cloud-music-tasks:latest
+
+### Upgrade
+
+不提供升级路径。上游和镜像均已停止发布，不应将重新构建成功误认为恢复维护。
+
+### Backup and restore
+
+```bash
+cp -p config.json config.json.backup
+chmod 600 config.json.backup
 ```
+
+备份应加密保存。恢复前轮换已经暴露或过期的 Cookie、Token 和推送凭据。
+
+### Stop and uninstall
+
+```bash
+docker rm -f netease-cloud-music-tasks
+```
+
+删除容器不会删除 bind-mounted `config.json`。确认完成迁移后，安全擦除其中的账号凭据。
+
+## Security
+
+- 归档代码可能包含未修复漏洞或不再兼容的登录流程。
+- `config.json` 包含敏感账号资料，不提交 Git，不粘贴到公开 Issue。
+- 不保证自动化行为符合第三方平台当前服务条款。
+- 不建议为恢复功能而下载来源不明的 Fork 或镜像。
+
+## Troubleshooting
+
+### 登录或任务接口失效
+
+这通常是归档项目与第三方 API 变化导致；本仓库不提供协议修复。优先停止容器并撤销凭据。
+
+### 容器循环重启
+
+```bash
+docker inspect netease-cloud-music-tasks --format '{{.State.ExitCode}} {{.State.Error}}'
+docker logs --tail=200 netease-cloud-music-tasks
+```
+
+保留日志用于迁移判断，但不要在公开报告中泄露 Cookie 或 Token。
+
+## Lifecycle and known limitations
+
+- 上游已归档；Docker Hub 最新镜像发布于 2022 年。
+- 本仓库仅保留静态检查和历史 AMD64 构建，以防资料无声腐化。
+- 镜像已从维护中的手动发布白名单移除。
+- 建议现有用户停止自动化任务、导出所需配置、撤销凭据并迁移到仍受维护的合法方案。

--- a/images/x-ui/README.md
+++ b/images/x-ui/README.md
@@ -1,55 +1,147 @@
-# x-ui
+# X-UI
 
-GitHub [enwaiax/x-ui](https://github.com/enwaiax/x-ui)
-Docker [enwaiax/x-ui](https://hub.docker.com/r/enwaiax/x-ui)
+> **Lifecycle:** `Moved`
+> **Image:** `enwaiax/x-ui:latest`
+> **Architectures:** `amd64`, `arm64`, `arm/v7`, `arm/v6`, `s390x` (historical manifest)
+> **Last verified:** `2026-08-15`
 
-此项目已独立为一个全新的项目，支持更多架构，支持两种版本的镜像
+> [!WARNING]
+> 本目录为历史部署入口。镜像维护已迁往独立仓库，当前 Dockerfile 还会克隆浮动上游，因此被排除在本仓库发布流水线之外。新部署请先查看 https://github.com/enwaiax/x-ui 。
 
-|                                                           | Tag    | amd64 | arm64 | armv7 | armv6 | s390x |
-| --------------------------------------------------------- | ------ | ----- | ----- | ----- | ----- | ----- |
-| [vaxilu/x-ui](https://github.com/vaxilu/x-ui)             | latest | ✅    | ✅    | ✅    | ✅    | ✅    |
-| [FranzKafkaYu/x-ui](https://github.com/FranzKafkaYu/x-ui) | alpha  | ✅    | ✅    | ❌    | ❌    | ✅    |
+## Overview
 
-Go to [enwaiax/x-ui](https://github.com/enwaiax/x-ui) to check the latest update
+- **Upstream:** https://github.com/vaxilu/x-ui
+- **Maintained image repository:** https://github.com/enwaiax/x-ui
+- **Docker Hub:** https://hub.docker.com/r/enwaiax/x-ui
+- **Source directory:** https://github.com/enwaiax/awesome-docker/tree/main/images/x-ui
+- **Recommended for new deployments:** `No`
 
-[English Version](docs/README_en.md)
+本文只帮助现有用户识别配置、备份和迁移。不要把这里的 `latest` 当作本仓库可复现发布物。
 
-## 简介
+## Prerequisites
 
-基于 [vaxilu/x-ui](https://github.com/vaxilu/x-ui) 项目的 docker 镜像.
+维护历史实例需要 Docker、当前数据库目录、证书目录、开放端口清单以及现有管理员凭据。该配置使用 host network，容器会直接共享宿主机网络命名空间。
 
-### docker 部署
+## Quick start
 
-```shell
+不提供新的推荐部署。历史命令如下，仅用于恢复已知版本：
+
+```bash
 mkdir x-ui && cd x-ui
-docker run -itd --network=host -v $PWD/db/:/etc/x-ui/ -v $PWD/cert/:/root/cert/ --name x-ui --restart=unless-stopped enwaiax/x-ui:latest
+docker run -d \
+  --name x-ui \
+  --restart unless-stopped \
+  --network host \
+  -v "$PWD/db:/etc/x-ui" \
+  -v "$PWD/cert:/root/cert:ro" \
+  enwaiax/x-ui:latest
 ```
 
-### docker compose 部署
+历史 Compose：
 
-```shell
-mkdir x-ui && cd x-ui
-curl -fsSL -o compose.yaml https://raw.githubusercontent.com/enwaiax/awesome-docker/main/images/x-ui/docker-compose.yml
-docker compose -f compose.yaml up -d
+```bash
+curl -fsSLo compose.yaml https://raw.githubusercontent.com/enwaiax/awesome-docker/main/images/x-ui/docker-compose.yml
+docker compose config
+docker compose up -d
 ```
 
-### 备份
+新部署应改用独立仓库经过验证的版本化文档。
 
-数据已经 mount 到 x-ui 路径下的 db 目录。备份整个 x-ui 文件夹后，可通过 `docker compose -f compose.yaml up -d` 恢复。
+## Configuration
 
-#### 证书
+### Environment variables
 
-容器起来后，将证书放置在`./x-ui/cert`即可，容器内的路径为`/root/cert/`
+历史镜像没有由本仓库维护的环境变量契约，主要配置位于数据库和证书挂载中。
 
-## 使用
+### Ports
 
-访问`http://服务器IP:54321`使用账号`admin`密码`admin`登录.注意需开放相关端口防火墙,并及时修改账号密码.
+由于 `network_mode: host`，Compose 不声明端口。历史面板默认常见端口为 `54321/TCP`，实际监听端口必须从当前实例配置和 `ss -lntp` 核实。
 
-## 忘记密码
+### Volumes
 
-删除当前路径下的 db 目录，重新部署容器，密码会被重置为`admin`
+| Host / volume | Container | Contains | Backup required |
+| --- | --- | --- | --- |
+| `./db` | `/etc/x-ui` | 面板数据库与核心配置 | Yes |
+| `./cert` | `/root/cert` | TLS 证书与私钥 | Yes, encrypted |
 
-## 参考
+### Network and privileges
 
-GitHub [vaxilu/x-ui](https://github.com/vaxilu/x-ui)  
-GitHub [stilleshan/dockerfiles](https://github.com/stilleshan/dockerfiles)
+使用 host network 会绕过 Docker 端口隔离。必须通过宿主机防火墙限制管理面板和代理端口，不要直接向公网开放管理入口。
+
+## First-run verification
+
+```bash
+docker ps --filter name=x-ui
+docker logs --tail=200 x-ui
+ss -lntp
+```
+
+首次登录后立即更改默认管理员凭据、面板端口和 URL path；实际操作以独立维护仓库当前版本文档为准。
+
+## Operations
+
+### Logs and status
+
+```bash
+docker logs -f --tail=200 x-ui
+docker inspect x-ui --format '{{.Config.Image}} {{.State.Status}}'
+```
+
+### Upgrade
+
+本仓库不提供升级保证。迁移前：
+
+1. 记录当前镜像 digest 和应用版本。
+2. 停止容器并完整备份 `db`、`cert`。
+3. 阅读独立仓库的迁移说明。
+4. 在隔离主机或复制数据上验证新版本。
+
+### Backup and restore
+
+```bash
+docker stop x-ui
+tar -czf x-ui-backup.tgz db cert
+docker start x-ui
+```
+
+恢复时先解压到新目录并用临时容器验证。**不要通过删除数据库来重置密码**；这会丢失全部面板和节点配置。密码恢复应使用当前版本官方命令或在备份副本上操作。
+
+### Stop and uninstall
+
+```bash
+docker rm -f x-ui
+```
+
+以上不会删除 `db` 和 `cert`。确认备份可恢复后才可手动删除数据目录。
+
+## Security
+
+- 立即替换默认账号密码；不要在公网使用默认管理入口。
+- host network 扩大暴露面，使用防火墙、访问控制、TLS 和非默认路径。
+- 私钥目录只读挂载并限制宿主机权限。
+- 当前目录不具备可复现发布保证；不要基于浮动构建结果建立供应链信任。
+- 不在 Issue 中粘贴数据库、节点配置、UUID、证书或订阅信息。
+
+## Troubleshooting
+
+### 面板无法访问
+
+```bash
+docker logs --tail=200 x-ui
+ss -lntp | grep -E 'x-ui|54321'
+```
+
+核对实际端口、宿主机防火墙、云安全组和面板 URL path。
+
+### 忘记密码
+
+不要删除 `db`。先备份，再查阅独立仓库当前版本的重置命令；若版本过老无法恢复，应在副本上迁移数据库或重建配置。
+
+## Lifecycle and known limitations
+
+- 生命周期为 Moved，本仓库不再发布该镜像。
+- 历史多架构信息来自现有 Docker Hub manifest，不代表当前源代码仍在全部架构上验证。
+- 当前 Dockerfile 克隆移动中的上游分支，因此只有静态/历史构建检查，没有发布资格。
+- 后续维护和新部署转移至 https://github.com/enwaiax/x-ui 。
+
+[English historical guide](docs/README_en.md)

--- a/images/x-ui/docker-compose.yml
+++ b/images/x-ui/docker-compose.yml
@@ -1,10 +1,13 @@
-version: '3.9'
 services:
   xui:
-    image: enwaiax/x-ui
-    container_name: x-ui
-    volumes:
-      - $PWD/db/:/etc/x-ui/
-      - $PWD/cert/:/root/cert/
+    image: enwaiax/x-ui:latest
     restart: unless-stopped
     network_mode: host
+    volumes:
+      - ./db:/etc/x-ui
+      - ./cert:/root/cert:ro
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/images/x-ui/docs/README_en.md
+++ b/images/x-ui/docs/README_en.md
@@ -1,143 +1,127 @@
-# x-ui docker image
+# X-UI historical Docker guide
 
-Go to [enwaiax/x-ui](https://github.com/enwaiax/x-ui) to check the latest update
+> **Lifecycle:** `Moved`
+> **Image:** `enwaiax/x-ui:latest`
+> **Architectures:** historical multi-architecture manifest
+> **Last verified:** `2026-08-15`
 
-> x-ui in docker version
+> This guide is retained for existing users. New deployments should use the maintained repository at https://github.com/enwaiax/x-ui.
 
-You could selecet your perfer one by changing the docker image tag
+## Overview
 
-|                                                           | Tag    | amd64 | arm64 | armv7 | armv6 | s390x |
-| --------------------------------------------------------- | ------ | ----- | ----- | ----- | ----- | ----- |
-| [vaxilu/x-ui](https://github.com/vaxilu/x-ui)             | latest | ✅    | ✅    | ✅    | ✅    | ✅    |
-| [FranzKafkaYu/x-ui](https://github.com/FranzKafkaYu/x-ui) | alpha  | ✅    | ✅    | ❌    | ❌    | ✅    |
+- **Upstream:** https://github.com/vaxilu/x-ui
+- **Maintained image repository:** https://github.com/enwaiax/x-ui
+- **Docker Hub:** https://hub.docker.com/r/enwaiax/x-ui
+- **Recommended for new deployments:** `No`
 
-### Why Should You Use Docker
+The image definition in this catalog is not reproducible because it clones a moving upstream branch during build. It is excluded from publishing here.
 
-- Consistent & Isolated Environment
-- Rapid Application Deployment
-- Ensures Scalability & Flexibility
-- Better Portability
-- Cost-Effective
-- In-Built Version Control System
-- Security
-- .....
+## Prerequisites
 
-### For this project, if you use docker
+Existing users need Docker, a backup of the database and certificate directories, the current image digest, and an inventory of every exposed host-network port.
 
-- You don't need to concern yourself with operating systems, architectures and other issues.
-- You will never ruin your Linux server. If you don't want to use it, you can stop or remove it from your environment exactly.
-- Last but not least, you can easily deploy and upgrade
+## Quick start
 
-### Hot to use it
-
-#### Pre-condition, Docker is installed
-
-Use the official one-key script
+Historical recovery command only:
 
 ```bash
-curl -sSL https://get.docker.com/ | sh
+docker run -d \
+  --name x-ui \
+  --restart unless-stopped \
+  --network host \
+  -v "$PWD/db:/etc/x-ui" \
+  -v "$PWD/cert:/root/cert:ro" \
+  enwaiax/x-ui:latest
 ```
 
-#### Start you container
+Historical Compose file:
 
-##### You could use the pre-build docker image enwaiax/xuiplus
-
-```
-mkdir x-ui && cd x-ui
-docker run -itd --network=host \
-    -v $PWD/db/:/etc/x-ui/ \
-    -v $PWD/cert/:/root/cert/ \
-    --name x-ui --restart=unless-stopped \
-    enwaiax/x-ui
-```
-
-Note: If you want to use [FranzKafkaYu/x-ui](https://github.com/FranzKafkaYu/x-ui), change the image as `enwaiax/x-ui:alpha`
-
-##### Or you could use docker compose to start it
-
-```
-mkdir x-ui && cd x-ui
-curl -fsSL -o compose.yaml https://raw.githubusercontent.com/enwaiax/awesome-docker/main/images/x-ui/docker-compose.yml
+```bash
+curl -fsSLo compose.yaml https://raw.githubusercontent.com/enwaiax/awesome-docker/main/images/x-ui/docker-compose.yml
+docker compose config
 docker compose up -d
 ```
 
-#### How to enable ssl to your x-ui panel
+## Configuration
 
-This part describe how to enable ssl.
+### Environment variables
 
-- Suppose your x-ui port is `54321`
-- Suppose your IP is `10.10.10.10`
-- Suppose your domain is `xui.example.com` and you have set the A recode in cloudflare
-- Suppose you are using Debian 10+ or Ubuntu 18+ system
-- Suppose your email is `xxxx@example.com`
+This catalog does not maintain an environment-variable contract for the historical image. Configuration is stored in the mounted database.
 
-##### Steps as below
+### Ports
 
-1. Install nginx and python3-certbot-nginx
+Host networking means ports are not listed in Compose. Inspect the live process with `ss -lntp`; the historical panel commonly used TCP 54321.
+
+### Volumes
+
+| Host | Container | Contents | Backup |
+| --- | --- | --- | --- |
+| `./db` | `/etc/x-ui` | Database and application configuration | Required |
+| `./cert` | `/root/cert` | TLS certificate and key | Required, encrypted |
+
+### Network and privileges
+
+The container uses the host network namespace. Restrict every panel and proxy port with the host firewall and cloud security groups.
+
+## First-run verification
 
 ```bash
-sudo apt update
-sudo apt install python3-certbot-nginx
+docker ps --filter name=x-ui
+docker logs --tail=200 x-ui
+ss -lntp
 ```
 
-2. Add new nging configurtion
+Immediately replace default credentials and move the management interface away from default settings, following the maintained repository's current instructions.
 
-```
-touch /etc/nginx/conf.d/xui.conf
-```
+## Operations
 
-Add below to the file. Adjust appropriately to your own situation.
+### Logs and status
 
-```nginx
-server {
-    listen 80;
-    listen [::]:80;
-    server_name xui.example.com;
-
-    location / {
-        proxy_redirect off;
-        proxy_pass http://127.0.0.1:54321;
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-    }
-
-    # This part desribe how to reverse websockt proxy
-     location /xray {
-         proxy_redirect off;
-         proxy_pass http://127.0.0.1:10001;
-         proxy_http_version 1.1;
-         proxy_set_header Upgrade $http_upgrade;
-         proxy_set_header Connection "upgrade";
-         proxy_set_header X-Real-IP $remote_addr;
-         proxy_set_header Host $http_host;
-         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-         proxy_set_header Y-Real-IP $realip_remote_addr;
-     }
-}
+```bash
+docker logs -f --tail=200 x-ui
+docker inspect x-ui --format '{{.Config.Image}} {{.State.Status}}'
 ```
 
-3. Check yout conf is OK
+### Upgrade
 
-```
-nginx -t
-```
+No upgrade is supported by this catalog. Back up data, record the current digest, and validate migration to the maintained repository on a copy of the database.
 
-4. Get cert
+### Backup and restore
 
-```
-certbot --nginx --agree-tos --no-eff-email --email xxxxx@example.com
-```
-
-For more details, refer to [cerbot](https://certbot.eff.org/)
-
-5. Reload nginx config
-
-```
-ngins -s reload
+```bash
+docker stop x-ui
+tar -czf x-ui-backup.tgz db cert
+docker start x-ui
 ```
 
-6. Test automatic renewal
+Restore to a separate directory first. Never delete the database as a password-reset technique; doing so destroys configuration.
 
+### Stop and uninstall
+
+```bash
+docker rm -f x-ui
 ```
-sudo certbot renew --dry-run
-```
+
+This keeps bind-mounted data. Delete it only after a tested migration and backup.
+
+## Security
+
+- Change default credentials immediately.
+- Do not expose the panel directly to the Internet.
+- Use TLS, firewall rules, access control, and a non-default management path.
+- Protect database, UUID, subscription, and private-key material.
+- Do not treat a successful floating-source build as a trusted release.
+
+## Troubleshooting
+
+### Panel is unreachable
+
+Inspect logs, actual listening ports, host firewall rules, cloud security groups, and the configured web path.
+
+### Password is lost
+
+Back up the database and use the reset procedure for the exact maintained version. Do not remove the data directory.
+
+## Lifecycle and known limitations
+
+This catalog entry is Moved and publish-disabled. Architecture claims describe the historical Docker Hub manifest only. Use https://github.com/enwaiax/x-ui for current releases and instructions.

--- a/scripts/validate-image-guides.py
+++ b/scripts/validate-image-guides.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Validate repository-owned image guides against the catalog contract."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+GUIDES = {
+    "maddy": ROOT / "images/maddy/README.md",
+    "download-bot": ROOT / "images/download-bot/README.md",
+    "netease-cloud-music-tasks": ROOT / "images/netease-cloud-music-tasks/README.md",
+    "x-ui": ROOT / "images/x-ui/README.md",
+    "firefox-send": ROOT / "images/firefox-send/README.md",
+}
+
+REQUIRED_HEADINGS = (
+    "Overview",
+    "Prerequisites",
+    "Quick start",
+    "Configuration",
+    "First-run verification",
+    "Operations",
+    "Security",
+    "Troubleshooting",
+    "Lifecycle and known limitations",
+)
+
+FORBIDDEN_PATTERNS = {
+    r"chmod\s+-R\s+777": "world-writable recursive permissions",
+    r"RPC_SECRET\s*=\s*P3TERX": "hard-coded default RPC secret",
+    r"删除[^\n]{0,30}(db|data)[^\n]{0,20}(目录|folder)": "destructive reset advice",
+    r"docker-compose\s": "legacy docker-compose command",
+}
+
+
+def heading_set(text: str) -> set[str]:
+    return {m.group(1).strip().lower() for m in re.finditer(r"^##\s+(.+?)\s*$", text, re.M)}
+
+
+def validate(slug: str, path: Path) -> list[str]:
+    errors: list[str] = []
+    if not path.is_file():
+        return [f"{path.relative_to(ROOT)}: missing guide"]
+
+    text = path.read_text(encoding="utf-8")
+    lower_headings = heading_set(text)
+    for heading in REQUIRED_HEADINGS:
+        if heading.lower() not in lower_headings:
+            errors.append(f"{path.relative_to(ROOT)}: missing '## {heading}'")
+
+    if not re.search(r"\*\*Lifecycle:\*\*\s*`?(Maintained|Community|Archived|Moved)`?", text):
+        errors.append(f"{path.relative_to(ROOT)}: missing valid Lifecycle metadata")
+    if "**Image:**" not in text:
+        errors.append(f"{path.relative_to(ROOT)}: missing Image metadata")
+    if "**Architectures:**" not in text:
+        errors.append(f"{path.relative_to(ROOT)}: missing Architectures metadata")
+    if not re.search(r"\*\*Last verified:\*\*\s*`?\d{4}-\d{2}-\d{2}`?", text):
+        errors.append(f"{path.relative_to(ROOT)}: missing ISO Last verified date")
+
+    for pattern, description in FORBIDDEN_PATTERNS.items():
+        if re.search(pattern, text, re.I):
+            errors.append(f"{path.relative_to(ROOT)}: contains {description}")
+
+    lifecycle = re.search(r"\*\*Lifecycle:\*\*\s*`?(\w+)", text)
+    if lifecycle and lifecycle.group(1) in {"Archived", "Moved"}:
+        if not re.search(r"Recommended for new deployments:\*\*\s*`?No`?", text, re.I):
+            errors.append(f"{path.relative_to(ROOT)}: archived/moved guide must say new deployments = No")
+
+    if slug in {"maddy", "download-bot"}:
+        if "### Docker CLI" not in text or "### Docker Compose" not in text:
+            errors.append(f"{path.relative_to(ROOT)}: active guide requires Docker CLI and Compose sections")
+
+    return errors
+
+
+def validate_compose_files() -> list[str]:
+    errors: list[str] = []
+    owned_compose = [
+        path
+        for path in sorted((ROOT / "images").glob("**/docker-compose.yml"))
+        if not any(part in {"send", "DownloadBot", "NeteaseCloudMusicTasks", "maddy", "x-ui"} for part in path.relative_to(ROOT / "images").parts[1:-1])
+    ]
+    for path in owned_compose:
+        text = path.read_text(encoding="utf-8")
+        if re.search(r"^version:\s*[\"']?[0-9]", text, re.M):
+            errors.append(f"{path.relative_to(ROOT)}: obsolete top-level Compose version key")
+        if "RPC_SECRET=P3TERX" in text or "RPC_SECRET: P3TERX" in text:
+            errors.append(f"{path.relative_to(ROOT)}: hard-coded default RPC secret")
+    return errors
+
+
+def main() -> int:
+    errors = [error for slug, path in GUIDES.items() for error in validate(slug, path)]
+    errors.extend(validate_compose_files())
+    if errors:
+        print("Image guide validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+    print(f"Validated {len(GUIDES)} image guides and Compose policy")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site/src/data/projects.ts
+++ b/site/src/data/projects.ts
@@ -154,7 +154,7 @@ export const projects: Project[] = [
     image: 'mozilla/send',
     upstream: 'https://github.com/mozilla/send',
     sourcePath: 'images/firefox-send',
-    guidePath: 'images/firefox-send/docker-compose.yml',
+    guidePath: 'images/firefox-send/README.md',
     architectures: ['AMD64'],
     tags: ['File sharing', 'Legacy', 'Compose'],
     ports: ['1443'],

--- a/site/src/data/projects.ts
+++ b/site/src/data/projects.ts
@@ -31,7 +31,7 @@ export const projects: Project[] = [
     name: 'Maddy Mail Server',
     eyebrow: 'Communication stack',
     summary: '一体化、低维护的个人邮件服务器。',
-    description: '用一个轻量守护进程替代 Postfix、Dovecot、OpenDKIM 等传统组合，并提供清晰的持久化、TLS 与 DNS 部署路径。',
+    description: '基于上游 Maddy v0.9.5，用一个轻量守护进程替代 Postfix、Dovecot、OpenDKIM 等传统组合，并提供清晰的持久化、TLS 与 DNS 部署路径。',
     category: '通信服务',
     status: 'maintained',
     statusLabel: 'Maintained',
@@ -52,7 +52,7 @@ export const projects: Project[] = [
   -v maddydata:/data \\
   -p 25:25 -p 143:143 -p 465:465 \\
   -p 587:587 -p 993:993 \\
-  enwaiax/maddy:latest`,
+  enwaiax/maddy:0.9.5`,
     compose: 'images/maddy/docker-compose.yml',
     notes: ['部署前确认 25 端口可用', '生产环境必须配置 TLS、SPF、DKIM 与 DMARC', '数据集中保存在 maddydata volume'],
   },


### PR DESCRIPTION
## Summary

Defines and applies a reusable image-guide contract so future images enter the catalog with complete, safe, and operationally useful documentation.

This PR is stacked on #16 because the standardized Maddy guide documents the v0.9.5 paths and commands introduced there. Merge #16 first, then retarget this PR to `main`.

## Guide standard

Adds `docs/image-guide-template.md` with required sections for:

- lifecycle, image version, architectures, and verification date;
- overview and deployment recommendation;
- prerequisites;
- Docker CLI and Docker Compose quick starts;
- environment variables, ports, volumes, networking, and privileges;
- first-run verification;
- logs, upgrade, backup/restore, and uninstall;
- security, troubleshooting, and known limitations.

Adds `scripts/validate-image-guides.py` and a required CI job. It validates all five catalog guides and rejects dangerous patterns such as recursive world-writable permissions, hard-coded aria2 RPC secrets, destructive database-reset advice, and legacy Compose commands. It also checks repository-owned Compose policy.

## Guide and Compose updates

- **Maddy:** complete v0.9.5 deployment, DNS/TLS, verification, backup, restore, upgrade, and troubleshooting guide.
- **Download Bot:** fixes the wrong title, documents config fields and secrets, removes the hard-coded RPC secret, replaces host networking/PWD mounts with an isolated Compose network and relative paths.
- **Netease Music Tasks:** converts the page to an archived-user maintenance and credential-cleanup guide.
- **X-UI:** makes Moved status explicit, explains host-network risk, and removes destructive “delete the database to reset password” advice in Chinese and English.
- **Firefox Send:** adds the previously missing Archived guide and modernizes the historical Compose network syntax.
- **RainLoop:** archives the add-on guide, removes insecure permission/default-password deployment instructions, and restricts its historical HTTP binding to localhost.

All repository-owned Compose files now omit obsolete top-level `version` keys and use consistent logging/volume syntax.

## Verification

- image guide contract: 5/5 pass;
- all repository-owned Compose files parse;
- Maddy and Download Bot Dockerfiles pass Buildx checks;
- Download Bot AMD64 image builds;
- Astro check and seven-page production build pass;
- npm production audit reports 0 vulnerabilities;
- actionlint and Python syntax checks pass;
- repository-owned guide links pass.

## Publishing impact

No Docker image is published or deleted. Documentation and historical Compose behavior are made safer, but archived entries remain explicitly unsupported for new deployments.
